### PR TITLE
Make datadelivery group optional in inventory

### DIFF
--- a/tasks/arc.yml
+++ b/tasks/arc.yml
@@ -13,7 +13,7 @@
     owner: "{{ submit_user.user }}"
     group: "{{ submit_user.group }}"
     mode: '0755'
-  with_items: "{{ groups['datadelivery'] }}"
+  with_items: "{% if groups['datadelivery'] is defined %}{{ groups['datadelivery'] }}{% else %}{{ groups['lrms_server'] }}{% endif %}"
   when: sessionbasename is defined and  sessionbasename|length >0 
 
 
@@ -25,7 +25,7 @@
     owner: "{{ submit_user.user }}"
     group: "{{ submit_user.group }}"
     mode: '0755'
-  with_items: "{{ groups['datadelivery'] }}"
+  with_items: "{% if groups['datadelivery'] is defined %}{{ groups['datadelivery'] }}{% else %}{{ groups['lrms_server'] }}{% endif %}"
   when: cachebasename is defined and cachebasename|length >0
 
 

--- a/templates/arc.conf.j2
+++ b/templates/arc.conf.j2
@@ -61,7 +61,12 @@ cachedir={{ cachebasename }}/cachedir-{{ server }}
 
 
 {% if remotedelivery == "yes" %}
+{% if groups['datadelivery'] is defined %}
 {% for server in groups['datadelivery'] %}
+deliveryservice=http://{{ hostvars[server].ansible_host }}:{{remotedelivery_port}}/datadeliveryservice
+{% endfor %}
+{% else %}
+{% for server in groups['lrms_server' ] %}
 deliveryservice=http://{{ hostvars[server].ansible_host }}:{{remotedelivery_port}}/datadeliveryservice
 {% endfor %}
 {% endif %}

--- a/templates/arc.conf.j2
+++ b/templates/arc.conf.j2
@@ -30,9 +30,11 @@ controldir={{ controldir }}
 
 {% if groups['datadelivery'] is defined %}
 {% for server in groups['datadelivery' ] %}
-{% if sessionbasename is defined and sessionbasename|length %}
 sessiondir={{ sessionbasename }}/sessiondir-{{ server }}
-{% endif %}
+{% endfor %}
+{% else %}
+{% for server in groups['lrms_server' ] %}
+sessiondir={{ sessionbasename }}/sessiondir-{{ server }}
 {% endfor %}
 {% endif %}
 
@@ -47,9 +49,11 @@ scratchdir={{ scratchdir }}
 [arex/cache]
 {% if groups['datadelivery'] is defined %}
 {% for server in groups['datadelivery'] %}
-{% if cachebasename is defined and cachebasename|length %}
 cachedir={{ cachebasename }}/cachedir-{{ server }}
-{% endif %}
+{% endfor %}
+{% else %}
+{% for server in groups['lrms_server' ] %}
+cachedir={{ cachebasename }}/cachedir-{{ server }}
 {% endfor %}
 {% endif %}
 

--- a/templates/arc.conf.j2
+++ b/templates/arc.conf.j2
@@ -70,6 +70,7 @@ deliveryservice=http://{{ hostvars[server].ansible_host }}:{{remotedelivery_port
 deliveryservice=http://{{ hostvars[server].ansible_host }}:{{remotedelivery_port}}/datadeliveryservice
 {% endfor %}
 {% endif %}
+{% endif %}
 
 
 [arex/ws]


### PR DESCRIPTION

With this PR, when there is no `datadelivery` group in the Ansible inventory, the head node of the cluster will be used (i.e. hosts under the group `lrms_server` in the inventory.